### PR TITLE
Added PHONY targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: wellknown.js index.js package.json
 all: wellknown.js
 
 wellknown.js: index.js package.json


### PR DESCRIPTION
Stops `make` from saying "x file is up to date". Thought this could have been why there was an up-to-date build in the repo?
