### PR TITLE
Support more than 3 dimensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,11 +227,7 @@ function stringify (gj) {
   }
 
   function pairWKT (c) {
-    if (c.length === 2) {
-      return c[0] + ' ' + c[1];
-    } else if (c.length === 3) {
-      return c[0] + ' ' + c[1] + ' ' + c[2];
-    }
+    return c.join(' ');
   }
 
   function ringWKT (r) {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports.stringify = stringify;
 
 var numberRegexp = /[-+]?([0-9]*\.[0-9]+|[0-9]+)([eE][-+]?[0-9]+)?/;
 // Matches sequences like '100 100' or '100 100 100'.
-var tuples = new RegExp('^' + numberRegexp.source + '\\s' + numberRegexp.source + '(\\s' + numberRegexp.source + ')?');
+var tuples = new RegExp('^' + numberRegexp.source + '(\\s' + numberRegexp.source + '){1,}');
 
 /*
  * Parse WKT and return GeoJSON.

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -11,7 +11,9 @@ test('wellknown', function(t) {
     var fixtures = [
         'LINESTRING (30 10, 10 30, 40 40)',
         'POINT (1 1)',
+        'POINT (1 1 1 1)',
         'LINESTRING (1 2 3, 4 5 6)',
+        'LINESTRING (1 2 3 4, 5 6 7 8)',
         'POLYGON ((30 10, 10 20, 20 40, 40 40, 30 10))',
         'POLYGON ((35 10, 10 20, 15 40, 45 45, 35 10), (20 30, 35 35, 30 20, 20 30))',
         'MULTIPOINT (1 1, 2 3)',

--- a/test/wellknown.test.js
+++ b/test/wellknown.test.js
@@ -32,6 +32,10 @@ test('wellknown', function(t) {
         type: 'Point',
         coordinates: [1, 2, 3]
     });
+    t.deepEqual(parse('point(1 2 3 4)'), {
+        type: 'Point',
+        coordinates: [1, 2, 3, 4]
+    });
     t.deepEqual(parse('SRID=3857;POINT (1 2 3)'), {
         type: 'Point',
         coordinates: [1, 2, 3],
@@ -57,6 +61,10 @@ test('wellknown', function(t) {
     t.deepEqual(parse('LINESTRING (1 2 3, 4 5 6)'), {
         type: 'LineString',
         coordinates: [[1, 2, 3], [4, 5, 6]]
+    });
+    t.deepEqual(parse('LINESTRING (1 2 3 4, 5 6 7 8)'), {
+        type: 'LineString',
+        coordinates: [[1, 2, 3, 4], [5, 6, 7, 8]]
     });
     t.deepEqual(parse('SRID=3857;LINESTRING (30 10, 10 30, 40 40)'), {
         type: 'LineString',


### PR DESCRIPTION
Adds support for N dimension geometries. Alternatively, this could be made to strictly support a max of 4 dimensions, though there is little harm in handling N dimensions for future-compatibility.

 Readme indicates 4 dimensions is supported, but that is incorrect.

Fixes #27 