### PR TITLE
add support for POINT Z, LINESTRING Z and POLYGON Z

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ function parse (input) {
   }
 
   function point () {
-    if (!$(/^(point)/i)) return null;
+    if (!$(/^(point\s?z?)/i)) return null;
     white();
     if (!$(/^(\()/)) return null;
     var c = coords();
@@ -154,7 +154,7 @@ function parse (input) {
   }
 
   function linestring () {
-    if (!$(/^(linestring)/i)) return null;
+    if (!$(/^(linestring\s?z?)/i)) return null;
     white();
     if (!$(/^(\()/)) return null;
     var c = coords();
@@ -167,7 +167,7 @@ function parse (input) {
   }
 
   function polygon () {
-    if (!$(/^(polygon)/i)) return null;
+    if (!$(/^(polygon\s?z?)/i)) return null;
     white();
     var c = multicoords();
     if (!c) return null;

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ function parse (input) {
   }
 
   function point () {
-    if (!$(/^(point\s?z?)/i)) return null;
+    if (!$(/^(point(\sz)?)/i)) return null;
     white();
     if (!$(/^(\()/)) return null;
     var c = coords();
@@ -154,7 +154,7 @@ function parse (input) {
   }
 
   function linestring () {
-    if (!$(/^(linestring\s?z?)/i)) return null;
+    if (!$(/^(linestring(\sz)?)/i)) return null;
     white();
     if (!$(/^(\()/)) return null;
     var c = coords();
@@ -167,7 +167,7 @@ function parse (input) {
   }
 
   function polygon () {
-    if (!$(/^(polygon\s?z?)/i)) return null;
+    if (!$(/^(polygon(\sz)?)/i)) return null;
     white();
     var c = multicoords();
     if (!c) return null;

--- a/test/wellknown.test.js
+++ b/test/wellknown.test.js
@@ -242,5 +242,21 @@ test('wellknown', function(t) {
     t.equal(parse('MULTIPOINT(1)'), null);
     t.equal(parse('MULTIPOINT(1 1, 1)'), null);
 
+
+    t.deepEqual(parse('POINT Z (1 2 3)'), {
+        type: 'Point',
+        coordinates: [1, 2, 3]
+    });
+
+    t.deepEqual(parse('LINESTRING Z (30 10 1, 10 30 2, 40 40 3)'), {
+        type: 'LineString',
+        coordinates: [[30, 10, 1], [10, 30, 2], [40, 40, 3]]
+    });
+
+    t.deepEqual(parse('POLYGON Z ((30 10 1, 10 20 2, 20 40 3, 40 40 4, 30 10 5))'), {
+        type: 'Polygon',
+        coordinates: [[[30, 10, 1], [10, 20, 2], [20, 40, 3], [40, 40, 4], [30, 10, 5]]]
+    });
+
     t.end();
 });


### PR DESCRIPTION
Added support for parsing POINT Z, LINESTRING Z and POLYGON Z, leveraging the support for 3d POINT, LINESTRING and POLYGON. 

Added simple tests for these cases, no existing tests broken. 

Should probably add support for ZM and M also, but that raises some questions: 

1. How to represent the M value in GeoJSON
2. How to wrap my head around the regex

However: The Z-variant covers our needs for now, and I would argue that it's better than nothing.

When it comes to standard support I'm not sure if this is in the spec, but I've found this 3d-representation in the wild, and I consider that enough incentive to implement it.


