### PR TITLE
Fixed a bug with leading whitespaces in WKT

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,6 +88,7 @@ function parse (input) {
   }
 
   function coords () {
+    white();
     var list = [];
     var item;
     var pt;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "license": "ISC",
   "devDependencies": {
+    "browserify": "^9.0.0",
     "fuzzer": "~0.2.0",
     "semistandard": "^8.0.0",
     "tap": "^6.2.0"

--- a/test/wellknown.test.js
+++ b/test/wellknown.test.js
@@ -20,6 +20,14 @@ test('wellknown', function(t) {
         type: 'Point',
         coordinates: [1, 1]
     });
+    t.deepEqual(parse('POINT( 1 1)'), {
+        type: 'Point',
+        coordinates: [1, 1]
+    });
+    t.deepEqual(parse('POINT ( 1 1)'), {
+        type: 'Point',
+        coordinates: [1, 1]
+    });
     t.deepEqual(parse('POINT(1.1 1.1)'), {
         type: 'Point',
         coordinates: [1.1, 1.1]
@@ -51,6 +59,14 @@ test('wellknown', function(t) {
         coordinates: [[30, 10], [10, 30], [40, 40]]
     });
     t.deepEqual(parse('LINESTRING(30 10, 10 30, 40 40)'), {
+        type: 'LineString',
+        coordinates: [[30, 10], [10, 30], [40, 40]]
+    });
+    t.deepEqual(parse('LINESTRING( 30 10, 10 30, 40 40)'), {
+        type: 'LineString',
+        coordinates: [[30, 10], [10, 30], [40, 40]]
+    });
+    t.deepEqual(parse('LINESTRING ( 30 10, 10 30, 40 40)'), {
         type: 'LineString',
         coordinates: [[30, 10], [10, 30], [40, 40]]
     });

--- a/wellknown.js
+++ b/wellknown.js
@@ -89,6 +89,7 @@ function parse (input) {
   }
 
   function coords () {
+    white();
     var list = [];
     var item;
     var pt;


### PR DESCRIPTION
Hi!

Not sure if this package gets updated too often anymore, but here's my 2 cents for fixing #36 which we've been running into recently.

Seems that the bug was caused by a missing `white()` call in the beginning of `coords()` - confirmed that everything still seems to work in unit tests after the fix.

Here's the list of changes:
* Added a `white()` call to fix #36
* Added a couple of unit test cases with leading whitespace characters
* Installed `browserify` to `devDependencies` to make `npm install` work without global installations
  * Tracked down the version by watching for changes to `wellknown.js` - seems that the version previously used was somewhere between 9.0.0 and 11.2.0 (chose the latest)