### PR TITLE
fix: allow multiple whitespace between coordinate ordinates (OGC WKT)

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports.stringify = stringify;
 
 var numberRegexp = /[-+]?([0-9]*\.[0-9]+|[0-9]+)([eE][-+]?[0-9]+)?/;
 // Matches sequences like '100 100' or '100 100 100'.
-var tuples = new RegExp('^' + numberRegexp.source + '(\\s' + numberRegexp.source + '){1,}');
+var tuples = new RegExp('^' + numberRegexp.source + '(\\s+' + numberRegexp.source + '){1,}');
 
 /*
  * Parse WKT and return GeoJSON.
@@ -74,8 +74,8 @@ function parse (input) {
       } else if (elem === ',') {
         pointer = [];
         stack[stack.length - 1].push(pointer);
-      } else if (!elem.split(/\s/g).some(isNaN)) {
-        Array.prototype.push.apply(pointer, elem.split(/\s/g).map(parseFloat));
+      } else if (!elem.split(/\s+/g).some(isNaN)) {
+        Array.prototype.push.apply(pointer, elem.split(/\s+/g).map(parseFloat));
       } else {
         return null;
       }
@@ -97,9 +97,9 @@ function parse (input) {
       if (pt === ',') {
         list.push(item);
         item = [];
-      } else if (!pt.split(/\s/g).some(isNaN)) {
+      } else if (!pt.split(/\s+/g).some(isNaN)) {
         if (!item) item = [];
-        Array.prototype.push.apply(item, pt.split(/\s/g).map(parseFloat));
+        Array.prototype.push.apply(item, pt.split(/\s+/g).map(parseFloat));
       }
       white();
     }

--- a/test/wellknown.test.js
+++ b/test/wellknown.test.js
@@ -258,5 +258,21 @@ test('wellknown', function(t) {
         coordinates: [[[30, 10, 1], [10, 20, 2], [20, 40, 3], [40, 40, 4], [30, 10, 5]]]
     });
 
+    // OGC SF WKT: the ordinate separator is one or more whitespace, so
+    // multiple spaces between ordinates denote the same geometry.
+    t.deepEqual(parse('POINT (1  2)'), parse('POINT (1 2)'));
+    t.deepEqual(parse('POINT (1  2)'), {
+        type: 'Point',
+        coordinates: [1, 2]
+    });
+    t.deepEqual(parse('LINESTRING (1  2, 3  4)'), {
+        type: 'LineString',
+        coordinates: [[1, 2], [3, 4]]
+    });
+    t.deepEqual(parse('POLYGON ((0 0, 1  0, 1 1, 0 0))'), {
+        type: 'Polygon',
+        coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]]
+    });
+
     t.end();
 });

--- a/wellknown.js
+++ b/wellknown.js
@@ -6,7 +6,7 @@ module.exports.stringify = stringify;
 
 var numberRegexp = /[-+]?([0-9]*\.[0-9]+|[0-9]+)([eE][-+]?[0-9]+)?/;
 // Matches sequences like '100 100' or '100 100 100'.
-var tuples = new RegExp('^' + numberRegexp.source + '(\\s' + numberRegexp.source + '){1,}');
+var tuples = new RegExp('^' + numberRegexp.source + '(\\s+' + numberRegexp.source + '){1,}');
 
 /*
  * Parse WKT and return GeoJSON.
@@ -75,8 +75,8 @@ function parse (input) {
       } else if (elem === ',') {
         pointer = [];
         stack[stack.length - 1].push(pointer);
-      } else if (!elem.split(/\s/g).some(isNaN)) {
-        Array.prototype.push.apply(pointer, elem.split(/\s/g).map(parseFloat));
+      } else if (!elem.split(/\s+/g).some(isNaN)) {
+        Array.prototype.push.apply(pointer, elem.split(/\s+/g).map(parseFloat));
       } else {
         return null;
       }
@@ -98,9 +98,9 @@ function parse (input) {
       if (pt === ',') {
         list.push(item);
         item = [];
-      } else if (!pt.split(/\s/g).some(isNaN)) {
+      } else if (!pt.split(/\s+/g).some(isNaN)) {
         if (!item) item = [];
-        Array.prototype.push.apply(item, pt.split(/\s/g).map(parseFloat));
+        Array.prototype.push.apply(item, pt.split(/\s+/g).map(parseFloat));
       }
       white();
     }


### PR DESCRIPTION
## Bug

`parse("POINT (1  2)")` returns `null` while `parse("POINT (1 2)")` returns `{type:'Point',coordinates:[1,2]}`. Two or more spaces between the X and Y ordinates of a coordinate tuple break parsing, even though a single space and a tab both parse fine:

```js
parse('POINT (1 2)');   // {type:'Point',coordinates:[1,2]}   ok (single space)
parse('POINT (1\t2)');  // {type:'Point',coordinates:[1,2]}   ok (tab)
parse('POINT (1  2)');  // null                               BUG (two spaces)
```

It affects every geometry type that uses coordinate tuples:

```
LINESTRING (1  2, 3  4)          -> null   (expected [[1,2],[3,4]])
POLYGON ((0 0, 1  0, 1 1, 0 0))  -> null
MULTIPOINT (1  2, 3  4)          -> null
```

## Spec

Under the OGC Simple Features WKT grammar the separator between ordinates inside a coordinate tuple is one or more whitespace, so `1 2`, `1  2` and `1\t2` all denote the same point. Accepting the single-space and tab forms while rejecting the multi-space form is an internal inconsistency, and real-world WKT (PostGIS output, pretty-printers, hand-aligned columns) commonly pads ordinates with multiple spaces.

## Root cause

Two spots assume exactly one whitespace between ordinates:

1. The `tuples` regex hard-codes a single `\s`, so on `"1  2"` it matches only `"1"` and the second ordinate is left unconsumed, then the closing `)` check fails and `parse` returns `null`.
2. The ordinate splitters in `coords()` and `multicoords()` use `split(/\s/g)`, so `"1  2".split(/\s/g)` yields `["1","","2"]` and `parseFloat("")` is `NaN`. Widening only the regex would inject a spurious `null` ordinate, so both need fixing together.

## Fix

Widen the `tuples` regex separator to `\s+` and the four ordinate splitters in `coords()` / `multicoords()` from `split(/\s/g)` to `split(/\s+/g)`. The bundled `wellknown.js` is updated to match `index.js`.

## Tests

Added assertions that double-spaced `POINT`, `LINESTRING` and `POLYGON` parse to the same GeoJSON as their single-spaced forms. They fail on `master` (return `null`) and pass with this change. The existing suite stays green (lint plus all prior assertions, including the single-space and tab cases and the stringify round-trip).

## Note

This is the ordinate-separator whitespace (between the X and Y of a tuple). It is distinct from issues #33 and #36, which concern whitespace adjacent to the parentheses (a different code path).
